### PR TITLE
uncomment the [submodule "GRH"] header in .gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	path = libm0common
 	url = https://github.com/io-sea/libm0common.git 
 	branch = next
-#[submodule "GRH"]
+[submodule "GRH"]
 	path = GRH
 	url = https://github.com/io-sea/GRH.git 
 	branch = next


### PR DESCRIPTION
Commented [submodule "GRH"] header in .gitmodules file is breaking the libm0common submodule mapping.  